### PR TITLE
Run specs via rake

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,2 +1,10 @@
 require "bundler/gem_tasks"
+require "rspec/core/rake_task"
+
+desc "Run the specs."
+RSpec::Core::RakeTask.new do |t|
+  t.pattern = "spec/**/*_spec.rb"
+  t.verbose = false
+end
+
 task :default => :spec


### PR DESCRIPTION
Previously, running `rake` or `rake spec` did nothing. This makes these commands actually run the spec suite, which appeared to be the intention of the boilerplated Rakefile.