### PR TITLE
Configure RSpec

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,5 @@
 /doc/
 /pkg/
 /spec/reports/
+/spec/examples.txt
 /tmp/

--- a/lib/json_api/response/object.rb
+++ b/lib/json_api/response/object.rb
@@ -41,7 +41,7 @@ module JSONApi
       def relationships
         return {} if @metadata[:relationships].blank?
         @relationships ||= @metadata[:relationships].each.with_object({}) do |(key, value), hash|
-          hash[key.to_sym] = JSONApi::Response::Body.new(value, @directory, @builder)
+          hash[key.to_sym] = JSONApi::Response::Body.new(value, @directory, nil)
         end
       end
 

--- a/spec/request/mapper_spec.rb
+++ b/spec/request/mapper_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 require 'support/member'
 
-describe JSONApi::Request::Mapper do
+RSpec.describe JSONApi::Request::Mapper do
 
   let(:stubs)      { Faraday::Adapter::Test::Stubs.new }
   let(:connection) { Faraday.new { |builder| builder.adapter(:test, stubs) } }

--- a/spec/request_spec.rb
+++ b/spec/request_spec.rb
@@ -1,4 +1,4 @@
 require 'spec_helper'
-describe JSONApi::Request do
 
+RSpec.describe JSONApi::Request do
 end

--- a/spec/response/body_spec.rb
+++ b/spec/response/body_spec.rb
@@ -1,7 +1,7 @@
 require 'support/member'
 require 'spec_helper'
 
-describe JSONApi::Response::Body do
+RSpec.describe JSONApi::Response::Body do
 
   let(:response_object) { Member }
   let(:directory)       { JSONApi::Response::TypeDirectory.new }

--- a/spec/response/object_spec.rb
+++ b/spec/response/object_spec.rb
@@ -2,7 +2,7 @@ require 'support/member'
 require 'support/member/venue'
 require 'spec_helper'
 
-describe JSONApi::Response::Object do
+RSpec.describe JSONApi::Response::Object do
 
   let(:directory)       { JSONApi::Response::TypeDirectory.new }
   let(:type)            { Member }

--- a/spec/response/type_directory_spec.rb
+++ b/spec/response/type_directory_spec.rb
@@ -1,7 +1,7 @@
 require 'support/member'
 require 'spec_helper'
 
-describe JSONApi::Response::TypeDirectory do
+RSpec.describe JSONApi::Response::TypeDirectory do
 
   let(:type) { Member }
 

--- a/spec/response/wrapper_spec.rb
+++ b/spec/response/wrapper_spec.rb
@@ -1,7 +1,7 @@
 require 'support/member'
 require 'spec_helper'
 
-describe JSONApi::Response::Wrapper do
+RSpec.describe JSONApi::Response::Wrapper do
 
   let(:type)            { Member }
   let(:directory)       { JSONApi::Response::TypeDirectory.new }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,87 +2,26 @@ require 'json_api'
 require 'pry'
 
 RSpec.configure do |config|
-  # rspec-expectations config goes here. You can use an alternate
-  # assertion/expectation library such as wrong or the stdlib/minitest
-  # assertions if you prefer.
   config.expect_with :rspec do |expectations|
-    # This option will default to `true` in RSpec 4. It makes the `description`
-    # and `failure_message` of custom matchers include text for helper methods
-    # defined using `chain`, e.g.:
-    #     be_bigger_than(2).and_smaller_than(4).description
-    #     # => "be bigger than 2 and smaller than 4"
-    # ...rather than:
-    #     # => "be bigger than 2"
     expectations.include_chain_clauses_in_custom_matcher_descriptions = true
   end
 
-  # rspec-mocks config goes here. You can use an alternate test double
-  # library (such as bogus or mocha) by changing the `mock_with` option here.
   config.mock_with :rspec do |mocks|
-    # Prevents you from mocking or stubbing a method that does not exist on
-    # a real object. This is generally recommended, and will default to
-    # `true` in RSpec 4.
     mocks.verify_partial_doubles = true
   end
 
-  # This option will default to `:apply_to_host_groups` in RSpec 4 (and will
-  # have no way to turn it off -- the option exists only for backwards
-  # compatibility in RSpec 3). It causes shared context metadata to be
-  # inherited by the metadata hash of host groups and examples, rather than
-  # triggering implicit auto-inclusion in groups with matching metadata.
   config.shared_context_metadata_behavior = :apply_to_host_groups
-
-# The settings below are suggested to provide a good initial experience
-# with RSpec, but feel free to customize to your heart's content.
-=begin
-  # This allows you to limit a spec run to individual examples or groups
-  # you care about by tagging them with `:focus` metadata. When nothing
-  # is tagged with `:focus`, all examples get run. RSpec also provides
-  # aliases for `it`, `describe`, and `context` that include `:focus`
-  # metadata: `fit`, `fdescribe` and `fcontext`, respectively.
   config.filter_run_when_matching :focus
-
-  # Allows RSpec to persist some state between runs in order to support
-  # the `--only-failures` and `--next-failure` CLI options. We recommend
-  # you configure your source control system to ignore this file.
   config.example_status_persistence_file_path = "spec/examples.txt"
-
-  # Limits the available syntax to the non-monkey patched syntax that is
-  # recommended. For more details, see:
-  #   - http://rspec.info/blog/2012/06/rspecs-new-expectation-syntax/
-  #   - http://www.teaisaweso.me/blog/2013/05/27/rspecs-new-message-expectation-syntax/
-  #   - http://rspec.info/blog/2014/05/notable-changes-in-rspec-3/#zero-monkey-patching-mode
   config.disable_monkey_patching!
-
-  # This setting enables warnings. It's recommended, but in some cases may
-  # be too noisy due to issues in dependencies.
   config.warnings = true
 
-  # Many RSpec users commonly either run the entire suite or an individual
-  # file, and it's useful to allow more verbose output when running an
-  # individual spec file.
   if config.files_to_run.one?
-    # Use the documentation formatter for detailed output,
-    # unless a formatter has already been configured
-    # (e.g. via a command-line flag).
     config.default_formatter = 'doc'
   end
 
-  # Print the 10 slowest examples and example groups at the
-  # end of the spec run, to help surface which specs are running
-  # particularly slow.
   config.profile_examples = 10
-
-  # Run specs in random order to surface order dependencies. If you find an
-  # order dependency and want to debug it, you can fix the order by providing
-  # the seed, which is printed after each run.
-  #     --seed 1234
   config.order = :random
 
-  # Seed global randomization in this process using the `--seed` CLI option.
-  # Setting this allows you to use `--seed` to deterministically reproduce
-  # test failures related to randomization by passing the same `--seed` value
-  # as the one that triggered the failure.
   Kernel.srand config.seed
-=end
 end


### PR DESCRIPTION
This uncomments the boilerplate `spec_helper.rb` to turn on some useful default configuration.

This configuration removes monkey-patching, so we now have to start each spec with `RSpec.describe`. This is fine.

This also highlights uninitialised variables. There was one.