### PR TITLE
Report coverage when running specs

### DIFF
--- a/.simplecov
+++ b/.simplecov
@@ -3,3 +3,4 @@ require 'simplecov-rcov'
 SimpleCov.formatter = SimpleCov::Formatter::RcovFormatter
 SimpleCov.root File.expand_path('..', __FILE__)
 SimpleCov.add_filter '/gems/'
+SimpleCov.add_filter '/spec/'

--- a/.simplecov
+++ b/.simplecov
@@ -1,0 +1,5 @@
+require 'simplecov-rcov'
+
+SimpleCov.formatter = SimpleCov::Formatter::RcovFormatter
+SimpleCov.root File.expand_path('..', __FILE__)
+SimpleCov.add_filter '/gems/'

--- a/json_api.gemspec
+++ b/json_api.gemspec
@@ -40,4 +40,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec"
   spec.add_development_dependency "pry"
+  spec.add_development_dependency 'simplecov'
+  spec.add_development_dependency 'simplecov-rcov'
 end

--- a/lib/json_api.rb
+++ b/lib/json_api.rb
@@ -1,5 +1,9 @@
-require "active_support"
-require "active_support/core_ext"
+require 'active_support/core_ext/hash/indifferent_access'
+require 'active_support/core_ext/hash/slice'
+require 'active_support/core_ext/module/delegation'
+require 'active_support/core_ext/object/blank'
+require 'active_support/core_ext/string/inflections'
+
 require 'mustermann'
 require 'mustermann/rails'
 require 'virtus'

--- a/lib/json_api/request/object.rb
+++ b/lib/json_api/request/object.rb
@@ -11,7 +11,7 @@ module JSONApi
       end
 
       def save
-        builder.post(as_json)
+        builder.post(attributes)
       end
 
     end

--- a/lib/json_api/response/object.rb
+++ b/lib/json_api/response/object.rb
@@ -23,7 +23,7 @@ module JSONApi
       end
 
       def save
-        builder.put(as_json)
+        builder.put(attributes)
       end
 
       def method_missing(method, *args, &block)

--- a/spec/request/mapper_spec.rb
+++ b/spec/request/mapper_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'json_api'
 require 'support/member'
 
 RSpec.describe JSONApi::Request::Mapper do

--- a/spec/request_spec.rb
+++ b/spec/request_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'json_api'
 
 RSpec.describe JSONApi::Request do
 end

--- a/spec/response/body_spec.rb
+++ b/spec/response/body_spec.rb
@@ -1,5 +1,5 @@
+require 'json_api'
 require 'support/member'
-require 'spec_helper'
 
 RSpec.describe JSONApi::Response::Body do
 

--- a/spec/response/object_spec.rb
+++ b/spec/response/object_spec.rb
@@ -1,6 +1,6 @@
+require 'json_api'
 require 'support/member'
 require 'support/member/venue'
-require 'spec_helper'
 
 RSpec.describe JSONApi::Response::Object do
 

--- a/spec/response/type_directory_spec.rb
+++ b/spec/response/type_directory_spec.rb
@@ -1,5 +1,5 @@
+require 'json_api'
 require 'support/member'
-require 'spec_helper'
 
 RSpec.describe JSONApi::Response::TypeDirectory do
 

--- a/spec/response/wrapper_spec.rb
+++ b/spec/response/wrapper_spec.rb
@@ -1,5 +1,5 @@
+require 'json_api'
 require 'support/member'
-require 'spec_helper'
 
 RSpec.describe JSONApi::Response::Wrapper do
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,9 +1,5 @@
-require 'json_api'
-require 'pry'
-
 require 'simplecov'
-require 'simplecov-rcov'
-SimpleCov.formatter = SimpleCov::Formatter::RcovFormatter
+require 'json_api'
 
 if ENV.key?('CIRCLE_ARTIFACTS')
   dir = File.join(ENV.fetch('CIRCLE_ARTIFACTS'), "coverage")

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,6 +5,11 @@ require 'simplecov'
 require 'simplecov-rcov'
 SimpleCov.formatter = SimpleCov::Formatter::RcovFormatter
 
+if ENV.key?('CIRCLE_ARTIFACTS')
+  dir = File.join(ENV.fetch('CIRCLE_ARTIFACTS'), "coverage")
+  SimpleCov.coverage_dir dir
+end
+
 RSpec.configure do |config|
   config.expect_with :rspec do |expectations|
     expectations.include_chain_clauses_in_custom_matcher_descriptions = true

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,4 @@
 require 'simplecov'
-require 'json_api'
 
 if ENV.key?('CIRCLE_ARTIFACTS')
   dir = File.join(ENV.fetch('CIRCLE_ARTIFACTS'), "coverage")

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,10 @@
 require 'json_api'
 require 'pry'
 
+require 'simplecov'
+require 'simplecov-rcov'
+SimpleCov.formatter = SimpleCov::Formatter::RcovFormatter
+
 RSpec.configure do |config|
   config.expect_with :rspec do |expectations|
     expectations.include_chain_clauses_in_custom_matcher_descriptions = true
@@ -18,6 +22,8 @@ RSpec.configure do |config|
 
   if config.files_to_run.one?
     config.default_formatter = 'doc'
+  else
+    SimpleCov.start
   end
 
   config.profile_examples = 10


### PR DESCRIPTION
This is skipped if only one file is being run, as the results in that case are unlikely to be helpful.