### PR TITLE
Fix bin/console

### DIFF
--- a/bin/console
+++ b/bin/console
@@ -1,14 +1,7 @@
 #!/usr/bin/env ruby
 
 require "bundler/setup"
-require "api_toolkit"
+require "json_api"
+require "pry"
 
-# You can add fixtures and/or initialization code here to make experimenting
-# with your gem easier. You can also use a different console, if you like.
-
-# (If you use this, don't forget to add pry to your Gemfile!)
-# require "pry"
-# Pry.start
-
-require "irb"
-IRB.start
+Pry.start


### PR DESCRIPTION
The namespace for the gem has changed so the require
was broken.

We are using Pry now so it should be safe to use
for the repl session.