### PR TITLE
Move require down to where needed

### DIFF
--- a/lib/json_api.rb
+++ b/lib/json_api.rb
@@ -1,14 +1,3 @@
-require 'active_support/core_ext/hash/indifferent_access'
-require 'active_support/core_ext/hash/slice'
-require 'active_support/core_ext/module/delegation'
-require 'active_support/core_ext/object/blank'
-require 'active_support/core_ext/string/inflections'
-
-require 'mustermann'
-require 'mustermann/rails'
-require 'virtus'
-require 'virtus/relations'
-
 require "json_api/version"
 
 require "json_api/request"

--- a/lib/json_api/model.rb
+++ b/lib/json_api/model.rb
@@ -1,3 +1,6 @@
+require 'virtus'
+require 'virtus/relations'
+
 module JSONApi
   class Model
     include Comparable

--- a/lib/json_api/request.rb
+++ b/lib/json_api/request.rb
@@ -1,9 +1,7 @@
-require 'json_api/request/mapper'
-require 'json_api/request/fragment'
-require 'json_api/request/fragment_collection'
 require 'json_api/request/builder'
-require 'json_api/request/route'
+require 'json_api/request/mapper'
 require 'json_api/request/object'
+require 'json_api/request/route'
 
 module JSONApi
   module Request

--- a/lib/json_api/request/builder.rb
+++ b/lib/json_api/request/builder.rb
@@ -1,3 +1,6 @@
+require 'json_api/request/fragment_collection'
+require 'json_api/request/object'
+
 module JSONApi
   module Request
     class Builder

--- a/lib/json_api/request/fragment.rb
+++ b/lib/json_api/request/fragment.rb
@@ -1,3 +1,5 @@
+require 'active_support/core_ext/object/blank'
+
 module JSONApi
   module Request
     class Fragment

--- a/lib/json_api/request/fragment_collection.rb
+++ b/lib/json_api/request/fragment_collection.rb
@@ -1,3 +1,5 @@
+require 'json_api/request/fragment'
+
 module JSONApi
   module Request
     class FragmentCollection

--- a/lib/json_api/request/mapper.rb
+++ b/lib/json_api/request/mapper.rb
@@ -1,3 +1,6 @@
+require 'json_api/request/builder'
+require 'json_api/request/route'
+
 module JSONApi
   module Request
     class Mapper

--- a/lib/json_api/request/object.rb
+++ b/lib/json_api/request/object.rb
@@ -1,3 +1,5 @@
+require 'active_support/core_ext/module/delegation'
+
 module JSONApi
   module Request
     class Object < SimpleDelegator

--- a/lib/json_api/request/route.rb
+++ b/lib/json_api/request/route.rb
@@ -1,3 +1,8 @@
+require 'active_support/core_ext/hash/slice'
+require 'active_support/core_ext/module/delegation'
+require 'mustermann'
+require 'mustermann/rails'
+
 module JSONApi
   module Request
     class Route

--- a/lib/json_api/response.rb
+++ b/lib/json_api/response.rb
@@ -1,13 +1,10 @@
-require 'faraday'
-
-require 'json_api/response/wrapper'
-require 'json_api/response/type_directory'
+require 'json_api/response/body'
 require 'json_api/response/middleware'
 require 'json_api/response/object'
-require 'json_api/response/body'
+require 'json_api/response/type_directory'
+require 'json_api/response/wrapper'
 
 module JSONApi
   module Response
   end
 end
-

--- a/lib/json_api/response/body.rb
+++ b/lib/json_api/response/body.rb
@@ -1,3 +1,6 @@
+require 'active_support/core_ext/module/delegation'
+require 'json_api/response/object'
+
 module JSONApi
   module Response
     class Body < SimpleDelegator

--- a/lib/json_api/response/middleware.rb
+++ b/lib/json_api/response/middleware.rb
@@ -1,3 +1,7 @@
+require 'faraday'
+require 'json_api/response/type_directory'
+require 'json_api/response/wrapper'
+
 module JSONApi
   module Response
     class Middleware < Faraday::Middleware

--- a/lib/json_api/response/object.rb
+++ b/lib/json_api/response/object.rb
@@ -1,3 +1,6 @@
+require 'active_support/core_ext/module/delegation'
+require 'active_support/core_ext/object/blank'
+
 module JSONApi
   module Response
     class Object < SimpleDelegator

--- a/lib/json_api/response/type_directory.rb
+++ b/lib/json_api/response/type_directory.rb
@@ -1,3 +1,7 @@
+require 'active_support/core_ext/hash/indifferent_access'
+require 'active_support/core_ext/module/delegation'
+require 'active_support/core_ext/string/inflections'
+
 module JSONApi
   module Response
     class TypeDirectory

--- a/lib/json_api/response/wrapper.rb
+++ b/lib/json_api/response/wrapper.rb
@@ -1,3 +1,6 @@
+require 'active_support/core_ext/hash/indifferent_access'
+require 'json_api/response/body'
+
 module JSONApi
   module Response
     class Wrapper

--- a/spec/request/mapper_spec.rb
+++ b/spec/request/mapper_spec.rb
@@ -1,4 +1,5 @@
-require 'json_api'
+require 'faraday'
+require 'json_api/request/mapper'
 require 'support/member'
 
 RSpec.describe JSONApi::Request::Mapper do

--- a/spec/request_spec.rb
+++ b/spec/request_spec.rb
@@ -1,4 +1,4 @@
-require 'json_api'
+require 'json_api/request'
 
 RSpec.describe JSONApi::Request do
 end

--- a/spec/response/body_spec.rb
+++ b/spec/response/body_spec.rb
@@ -1,4 +1,5 @@
-require 'json_api'
+require 'json_api/response/body'
+require 'json_api/response/type_directory'
 require 'support/member'
 
 RSpec.describe JSONApi::Response::Body do

--- a/spec/response/object_spec.rb
+++ b/spec/response/object_spec.rb
@@ -1,4 +1,6 @@
-require 'json_api'
+require 'json_api/response/body'
+require 'json_api/response/object'
+require 'json_api/response/type_directory'
 require 'support/member'
 require 'support/member/venue'
 

--- a/spec/response/type_directory_spec.rb
+++ b/spec/response/type_directory_spec.rb
@@ -1,4 +1,4 @@
-require 'json_api'
+require 'json_api/response/type_directory'
 require 'support/member'
 
 RSpec.describe JSONApi::Response::TypeDirectory do

--- a/spec/response/wrapper_spec.rb
+++ b/spec/response/wrapper_spec.rb
@@ -1,4 +1,6 @@
-require 'json_api'
+require 'json_api/response/body'
+require 'json_api/response/type_directory'
+require 'json_api/response/wrapper'
 require 'support/member'
 
 RSpec.describe JSONApi::Response::Wrapper do

--- a/spec/support/member.rb
+++ b/spec/support/member.rb
@@ -1,3 +1,5 @@
+require 'json_api/model'
+
 class Member < JSONApi::Model
 
   attribute :id,   String

--- a/spec/support/member/venue.rb
+++ b/spec/support/member/venue.rb
@@ -1,3 +1,5 @@
+require 'json_api/model'
+
 class Member
   class Venue < JSONApi::Model
 


### PR DESCRIPTION
This allows better-isolated testing.

Unfortunately, there is a circular dependency between `Response::Body` and `Response::Object`, which has been solved by not requiring `body` from `object.rb` and ensuring that `body` is required first in `response.rb` and in `object_spec.rb`.